### PR TITLE
Fix: runtime error: slice bounds out of range

### DIFF
--- a/contextmanager.go
+++ b/contextmanager.go
@@ -50,7 +50,7 @@ type contextManager struct {
 // Create an empty contextManager
 func newContextManager(label string) *contextManager {
 	c := &contextManager{
-		label: label,
+		label:                            label,
 		contextIDToAbstractSyntaxNameMap: make(map[byte]*contextManagerEntry),
 		abstractSyntaxNameToContextIDMap: make(map[string]*contextManagerEntry),
 		peerMaxPDUSize:                   16384, // The default value used by Osirix & pynetdicom.
@@ -150,7 +150,9 @@ func (m *contextManager) onAssociateRequest(requestItems []pdu.SubItem) ([]pdu.S
 			for _, subItem := range ri.Items {
 				switch c := subItem.(type) {
 				case *pdu.UserInformationMaximumLengthItem:
-					m.peerMaxPDUSize = int(c.MaximumLengthReceived)
+					if int(c.MaximumLengthReceived) > 0 {
+						m.peerMaxPDUSize = int(c.MaximumLengthReceived)
+					}
 				case *pdu.ImplementationClassUIDSubItem:
 					m.peerImplementationClassUID = c.Name
 				case *pdu.ImplementationVersionNameSubItem:


### PR DESCRIPTION
The maximum PDU length value is indicated as a number of bytes encoded as an unsigned binary number. The value of (0) indicates that no maximum length is specified, we should revert it back to the default value.
https://dicom.nema.org/medical/dicom/current/output/html/part08.html
```
panic: runtime error: slice bounds out of range [:-8]

goroutine 801 [running]:
[github.com/grailbio/go-netdicom.splitDataIntoPDUs](http://github.com/grailbio/go-netdicom.splitDataIntoPDUs)(0xc001a1f0e0, {0xc0031fc5b8, 0x11}, 0x1, {0xc00438c980, 0x34, 0x40})
/builds/segmed/dataops/.go/pkg/mod/github.com/segmed/go-netdicom@v0.0.0-20210713025048-09b676c9ed12/statemachine.go:299 +0x335
[github.com/grailbio/go-netdicom.glob..func9](http://github.com/grailbio/go-netdicom.glob..func9)(0xc001a1f0e0, {0x9, {0x0, 0x0}, {0x0, 0x0}, {0x0, 0x0}, 0xc0018ddf00, 0x0})
/builds/segmed/dataops/.go/pkg/mod/github.com/segmed/go-netdicom@v0.0.0-20210713025048-09b676c9ed12/statemachine.go:327 +0x252
[github.com/grailbio/go-netdicom.runOneStep(0xc001a1f0e0)](http://github.com/grailbio/go-netdicom.runOneStep(0xc001a1f0e0))
/builds/segmed/dataops/.go/pkg/mod/github.com/segmed/go-netdicom@v0.0.0-20210713025048-09b676c9ed12/statemachine.go:926 +0x536
[github.com/grailbio/go-netdicom.runStateMachineForServiceProvider](http://github.com/grailbio/go-netdicom.runStateMachineForServiceProvider)({0x15b20d8, 0xc00000f710}, 0xc0017aac60, 0xc0017aacc0, {0xc0017b48e0, 0x6})
/builds/segmed/dataops/.go/pkg/mod/github.com/segmed/go-netdicom@v0.0.0-20210713025048-09b676c9ed12/statemachine.go:982 +0x3aa
created by [github.com/grailbio/go-netdicom.RunProviderForConn](http://github.com/grailbio/go-netdicom.RunProviderForConn)
/builds/segmed/dataops/.go/pkg/mod/github.com/segmed/go-netdicom@v0.0.0-20210713025048-09b676c9ed12/serviceprovider.go:518 +0x69b
```