### PR TITLE
Introduce C-MOVE implemented for SCU

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@ examples.
 
 Inspired by https://github.com/pydicom/pynetdicom3.
 
+Status as of 2022-18-05:
+- C-MOVE works on the client side
+
 Status as of 2017-10-02:
 
 - C-STORE, C-FIND, C-GET work, both for the client and the server. Look at
@@ -21,8 +24,7 @@ TODO:
 
 - Better SSL support.
 
-- Implement the rest of DIMSE protocols, in particular C-MOVE on the client
-  side, and N-* commands.
+- Implement the rest of DIMSE protocols, in particular N-* commands.
 
 - Better message validation.
 

--- a/sampleclient/sampleclient.go
+++ b/sampleclient/sampleclient.go
@@ -17,16 +17,19 @@ var (
 	storeFlag         = flag.String("store", "", "If set, issue C-STORE to copy this file to the remote server")
 	aeTitleFlag       = flag.String("ae-title", "testclient", "AE title of the client")
 	remoteAETitleFlag = flag.String("remote-ae-title", "testserver", "AE title of the server")
+	moveAETitleFlag   = flag.String("move-ae-title", "testdestination", "AE title of the move destination")
 	findFlag          = flag.Bool("find", false, "Issue a C-FIND.")
 	getFlag           = flag.Bool("get", false, "Issue a C-GET.")
-	seriesFlag        = flag.String("series", "", "Study series UID to retrieve in C-{FIND,GET}.")
-	studyFlag         = flag.String("study", "", "Study instance UID to retrieve in C-{FIND,GET}.")
+	moveFlag          = flag.Bool("move", false, "Issue a C-MOVE.")
+	seriesFlag        = flag.String("series", "", "Study series UID to retrieve in C-{FIND,GET,MOVE}.")
+	studyFlag         = flag.String("study", "", "Study instance UID to retrieve in C-{FIND,GET,MOVE}.")
 )
 
 func newServiceUser(sopClasses []string) *netdicom.ServiceUser {
 	su, err := netdicom.NewServiceUser(netdicom.ServiceUserParams{
 		CalledAETitle:  *remoteAETitleFlag,
 		CallingAETitle: *aeTitleFlag,
+		MoveAETitle:    *moveAETitleFlag,
 		SOPClasses:     sopClasses})
 	if err != nil {
 		log.Panic(err)
@@ -78,6 +81,14 @@ func generateCFindElements() (netdicom.QRLevel, []*dicom.Element) {
 	return netdicom.QRLevelPatient, args
 }
 
+func cMove() {
+	su := newServiceUser(sopclass.QRMoveClasses)
+	defer su.Release()
+	qrLevel, args := generateCFindElements()
+	err := su.CMove(qrLevel, args)
+	log.Printf("C-MOVE finished: %v", err)
+}
+
 func cGet() {
 	su := newServiceUser(sopclass.QRGetClasses)
 	defer su.Release()
@@ -117,7 +128,9 @@ func main() {
 		cFind()
 	} else if *getFlag {
 		cGet()
+	} else if *moveFlag {
+		cMove()
 	} else {
-		log.Panic("Either -store, -get, or -find must be set")
+		log.Panic("Either -store, -get, -move, or -find must be set")
 	}
 }

--- a/sampleclient/sampleclient.go
+++ b/sampleclient/sampleclient.go
@@ -29,7 +29,6 @@ func newServiceUser(sopClasses []string) *netdicom.ServiceUser {
 	su, err := netdicom.NewServiceUser(netdicom.ServiceUserParams{
 		CalledAETitle:  *remoteAETitleFlag,
 		CallingAETitle: *aeTitleFlag,
-		MoveAETitle:    *moveAETitleFlag,
 		SOPClasses:     sopClasses})
 	if err != nil {
 		log.Panic(err)
@@ -85,8 +84,11 @@ func cMove() {
 	su := newServiceUser(sopclass.QRMoveClasses)
 	defer su.Release()
 	qrLevel, args := generateCFindElements()
-	err := su.CMove(qrLevel, args)
-	log.Printf("C-MOVE finished: %v", err)
+	if err := su.CMove(*moveAETitleFlag, qrLevel, args); err != nil {
+		log.Printf("C-MOVE error: %v", err)
+	} else {
+		log.Print("C-MOVE finished")
+	}
 }
 
 func cGet() {


### PR DESCRIPTION
Introduce C-MOVE implemented for SCU
### How to test
- Create a default configuration file called `dcmqrscp.cfg`
```
NetworkTCPPort  = 5104
MaxPDUSize      = 16384
MaxAssociations = 16

HostTable BEGIN
segmed_ae       = (segmed_ae, localhost, 7250)
acmeCTcompany   = segmed_ae
HostTable END

VendorTable BEGIN
"Acme CT Company"   = acmeCTcompany
VendorTable END

AETable BEGIN
ANY-SCP   .   RW (100, 1024mb)   acmeCTcompany
AETable END
```
- start dcmqrscp, that creates a PACS server listen on port 5104
```
dcmqrscp -v --config dcmqrscp.cfg
```
- start an SCP that listens for Storage SOP Class requests
```
storescp -v 7250 -od /tmp/od
```
- transfer a DICOM image to dcmqrscp
```
dcmsend -v localhost 5104 /path/to/image.dcm -aet segmed_ae
```
- Retrieving image from PACS using `sampleclient`
```
cd sampleclient && go build
./sampleclient -move -server localhost:5104 -ae-title segmed_ae-move-ae-title segmed_ae -remote-ae-title ANY-SCP -study 1.2.826.0.1.3680043.2.1143.2592092611698916978113112155415165916
```
- Observe files received in `/tmp/od` dir
```
ls /tmp/od
```





