### PR TITLE
Prefer Explicit VR Little Endian instead of Implicit VR Little Endian

### DIFF
--- a/global.go
+++ b/global.go
@@ -1,8 +1,8 @@
 package netdicom
 
 var allTransferSyntaxes = []string{
-	"1.2.840.10008.1.2",       // Implicit VR Little Endian,
 	"1.2.840.10008.1.2.1",     // Explicit VR Little Endian,
+	"1.2.840.10008.1.2",       // Implicit VR Little Endian,
 	"1.2.840.10008.1.2.1.99",  // Deflated Explicit VR Little Endian
 	"1.2.840.10008.1.2.2",     // Explicit VR Big Endian,
 	"1.2.840.10008.1.2.4.50",  // JPEG Baseline


### PR DESCRIPTION
Due to this issue https://github.com/suyashkumar/dicom/issues/220, we should prefer `Explicit VR Little Endian` instead.