### PR TITLE
Fix supported SOP Classes for issuing C-MOVE requests

### DIFF
--- a/sopclass/sopclass.go
+++ b/sopclass/sopclass.go
@@ -152,9 +152,9 @@ var QRFindClasses = []string{
 
 // QRMoveClasses is for issuing C-MOVE requests.
 var QRMoveClasses = []string{
-	standardUID("1.2.840.10008.5.1.4.1.2.1.2"),
+	standardUID("1.2.840.10008.5.1.4.1.2.2.1"),
 	standardUID("1.2.840.10008.5.1.4.1.2.2.2"),
-	standardUID("1.2.840.10008.5.1.4.1.2.3.2")}
+}
 
 // QRGetClasses is for issuing C-GET requests.
 var QRGetClasses = append([]string{


### PR DESCRIPTION
According to the `movescu` man page, we should add `FINDStudyRootQueryRetrieveInformationModel` SOP Class to conform with the RSNA'93 demonstration:
```
       The movescu application will propose presentation contexts for one of the abovementioned supported SOP Classes depending on
       the command line options (-P, -S, or -O). It will also propose the corresponding SOP Class from the following list, although
       it is not really used (this is a relict of the RSNA'93 demonstration):

       FINDPatientRootQueryRetrieveInformationModel         1.2.840.10008.5.1.4.1.2.1.1
       FINDStudyRootQueryRetrieveInformationModel           1.2.840.10008.5.1.4.1.2.2.1
       FINDPatientStudyOnlyQueryRetrieveInformationModel    1.2.840.10008.5.1.4.1.2.3.1
```