### PR TITLE
fix panic when status != 0

### DIFF
--- a/sampleclient/sampleclient.go
+++ b/sampleclient/sampleclient.go
@@ -6,7 +6,9 @@ import (
 	"log"
 
 	"github.com/grailbio/go-dicom"
+	"github.com/grailbio/go-dicom/dicomlog"
 	"github.com/grailbio/go-dicom/dicomtag"
+
 	"github.com/grailbio/go-netdicom"
 	"github.com/grailbio/go-netdicom/dimse"
 	"github.com/grailbio/go-netdicom/sopclass"
@@ -14,6 +16,7 @@ import (
 
 var (
 	serverFlag        = flag.String("server", "localhost:10000", "host:port of the remote application entity")
+	logLevelFlag      = flag.Int("log", 0, `the log level of client. Available: 0,1`)
 	storeFlag         = flag.String("store", "", "If set, issue C-STORE to copy this file to the remote server")
 	aeTitleFlag       = flag.String("ae-title", "testclient", "AE title of the client")
 	remoteAETitleFlag = flag.String("remote-ae-title", "testserver", "AE title of the server")
@@ -128,6 +131,7 @@ func cFind() {
 
 func main() {
 	flag.Parse()
+	dicomlog.SetLevel(*logLevelFlag)
 	if *storeFlag != "" {
 		cStore(*storeFlag)
 	} else if *findFlag {

--- a/serviceuser.go
+++ b/serviceuser.go
@@ -403,6 +403,7 @@ func (su *ServiceUser) CFind(qrLevel QRLevel, filter []*dicom.Element) chan CFin
 			switch resp.Status.Status {
 			case dimse.StatusPending:
 				dicomlog.Vprintf(1, "dicom.serviceUser: C-FIND received pending response: %+v", elems)
+				ch <- CFindResult{Elements: elems}
 				continue receiveLoop
 			case dimse.StatusSuccess:
 				dicomlog.Vprintf(1, "dicom.serviceUser: C-FIND received response success: %+v", elems)

--- a/serviceuser.go
+++ b/serviceuser.go
@@ -399,19 +399,18 @@ func (su *ServiceUser) CFind(qrLevel QRLevel, filter []*dicom.Element) chan CFin
 			if err != nil {
 				dicomlog.Vprintf(0, "dicom.serviceUser: Failed to decode C-FIND response: %v %v", resp.String(), err)
 				ch <- CFindResult{Err: err}
-			} else {
-				ch <- CFindResult{Elements: elems}
 			}
 			switch resp.Status.Status {
 			case dimse.StatusPending:
+				dicomlog.Vprintf(1, "dicom.serviceUser: C-FIND received pending response: %+v", elems)
 				continue receiveLoop
 			case dimse.StatusSuccess:
-				dicomlog.Vprintf(1, "dicom.serviceUser: C-MOVE received response success: %+v", elems)
+				dicomlog.Vprintf(1, "dicom.serviceUser: C-FIND received response success: %+v", elems)
 				ch <- CFindResult{Elements: elems}
 				break receiveLoop
 			default:
 				e := fmt.Errorf("received C-MOVE error: %+v", resp)
-				dicomlog.Vprintf(0, "dicom.serviceUser: C-MOVE received response not success: %v", e)
+				dicomlog.Vprintf(0, "dicom.serviceUser: C-FIND received response not success: %v", e)
 				ch <- CFindResult{Err: e}
 				break receiveLoop
 			}
@@ -485,8 +484,10 @@ receiveLoop:
 		}
 		switch resp.Status.Status {
 		case dimse.StatusPending:
+			dicomlog.Vprintf(1, "dicom.serviceUser: C-GET received pending response")
 			continue receiveLoop
 		case dimse.StatusSuccess:
+			dicomlog.Vprintf(1, "dicom.serviceUser: C-GET received success response")
 			break receiveLoop
 		default:
 			e := fmt.Errorf("received C-GET error: %+v", resp)
@@ -536,6 +537,7 @@ receiveLoop:
 		}
 		switch resp.Status.Status {
 		case dimse.StatusPending:
+			dicomlog.Vprintf(1, "dicom.serviceUser: C-MOVE received pending response")
 			continue receiveLoop
 		case dimse.StatusSuccess:
 			dicomlog.Vprintf(1, "dicom.serviceUser: C-MOVE received response success: %+v", resp)


### PR DESCRIPTION
# Description:
- Fix panic when status != StatusPending and status != StatusSuccess
- Add more logging

# How to test 
- Create a default configuration file called dcmqrscp.cfg
```
NetworkTCPPort  = 5104
MaxPDUSize      = 16384
MaxAssociations = 16

HostTable BEGIN
segmed_ae       = (segmed_ae, localhost, 7250)
acmeCTcompany   = segmed_ae
HostTable END

VendorTable BEGIN
"Acme CT Company"   = acmeCTcompany
VendorTable END

AETable BEGIN
ANY-SCP   .   RW (100, 1024mb)   acmeCTcompany
AETable END
```
- start dcmqrscp, that creates a PACS server listen on port 5104
```bash
dcmqrscp -v --config dcmqrscp.cfg
```
- Send the DICOM to PACS
```bash
dcmsend -v localhost 5104 $path_dcm -aet segmed_ae
```
- Test with this client

```bash
cd sampleclient
go build
./sampleclient --find --ae-title segmed_ae --study $study_id --server localhost:5104 --remote-ae-title ANY-SCP --log 1
```

You will see 2 lines
```
2022/07/14 14:47:07 dicom.serviceUser: C-FIND received pending response: [ (0008,0052)[QueryRetrieveLevel] CS  [STUDY]  (0008,0054)[RetrieveAETitle] AE  [ANY-SCP]  (0020,000d)[StudyInstanceUID] UI  [14432.510336577533125033571087322761341]]
2022/07/14 14:47:07 dicom.serviceUser: C-FIND received response success: []
```
