### PR TITLE
Streaming DICOM file download for avoiding out of memory errors

### DIFF
--- a/dimse/dimse.go
+++ b/dimse/dimse.go
@@ -296,9 +296,10 @@ func NewCommandAssembler() CommandAssembler {
 	}
 }
 
-type AddDataPDUResults struct {
-	First     bool
-	Last      bool
+// AddDataPDUResult is for adding PDU results
+type AddDataPDUResult struct {
+	First     bool // First fragment if there's no data in buffer
+	Last      bool // Last fragment if the PDU marked as the last one
 	ContextID byte
 	Command   Message
 	DataBytes []byte
@@ -309,8 +310,8 @@ type AddDataPDUResults struct {
 // network. If the fragment is marked as the last one, AddDataPDU returns
 // <SOPUID, TransferSyntaxUID, payload, nil>.  If it needs more fragments, it
 // returns <"", "", nil, nil>.  On error, it returns a non-nil error.
-func (a *CommandAssembler) AddDataPDU(pdu *pdu.PDataTf) (AddDataPDUResults, error) {
-	var result AddDataPDUResults
+func (a *CommandAssembler) AddDataPDU(pdu *pdu.PDataTf) (AddDataPDUResult, error) {
+	var result AddDataPDUResult
 	result.First = len(a.dataBytes) == 0
 	result.Stream = a.stream
 	for _, item := range pdu.Items {

--- a/sampleserver/client_test.go
+++ b/sampleserver/client_test.go
@@ -13,7 +13,7 @@ import (
 func TestClient_Echo(t *testing.T) {
 	var port = MustAllocateFreePort()
 	go func() {
-		runSCP(net.JoinHostPort("localhost", port), "", nil, nil)
+		runSCP(net.JoinHostPort("localhost", port), "", true, nil, nil)
 	}()
 	waitForReply(t, port)
 }

--- a/sampleserver/sampleserver.go
+++ b/sampleserver/sampleserver.go
@@ -14,6 +14,8 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
+	"net/http"
+	_ "net/http/pprof"
 	"os"
 	"path"
 	"path/filepath"
@@ -403,5 +405,8 @@ func runSCP(port string, dir string, remoteAEs map[string]string, tlsConfig *tls
 	if err != nil {
 		panic(err)
 	}
+	go func() {
+		fmt.Println(http.ListenAndServe("localhost:6060", nil))
+	}()
 	sp.Run()
 }

--- a/sampleserver/sampleserver.go
+++ b/sampleserver/sampleserver.go
@@ -64,9 +64,6 @@ func (ss *server) onCStoreStream(
 	sopClassUID string,
 	sopInstanceUID string,
 	dataCh chan []byte) dimse.Status {
-	ss.mu.Lock()
-	defer ss.mu.Unlock()
-
 	buf := bytes.Buffer{}
 
 	e := dicomio.NewEncoderWithTransferSyntax(&buf, transferSyntaxUID)
@@ -82,7 +79,7 @@ func (ss *server) onCStoreStream(
 			log.Printf("write: %v", err)
 			return dimse.Status{Status: dimse.StatusNotAuthorized, ErrorComment: err.Error()}
 		}
-		log.Printf("C-STORE: Stored %v MB in buffer", len(buf.Bytes())/1024/1024)
+		log.Printf("C-STORE: Stored %.2f MB in buffer", float64(len(buf.Bytes()))/1024/1024)
 	}
 	return dimse.Success
 }
@@ -361,7 +358,7 @@ func main() {
 func runSCP(port string, dir string, remoteAEs map[string]string, tlsConfig *tls.Config) {
 	datasets, err := listDicomFiles(dir)
 	if err != nil {
-		log.Panicf("Failed to list DICOM files in %s: %v", *dirFlag, err)
+		log.Panicf("Failed to list DICOM files in %s: %v", dir, err)
 	}
 	ss := server{
 		mu:       &sync.Mutex{},

--- a/sampleserver/sampleserver_test.go
+++ b/sampleserver/sampleserver_test.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"crypto/rand"
+	"log"
+	"net"
+	"sync"
+	"testing"
+
+	godicom "github.com/grailbio/go-dicom"
+	"github.com/grailbio/go-dicom/dicomtag"
+	"github.com/grailbio/go-netdicom"
+	"github.com/grailbio/go-netdicom/dimse"
+	"github.com/grailbio/go-netdicom/sopclass"
+	"github.com/stretchr/testify/require"
+)
+
+func runSCPTest(t testing.TB, port, aeTitle string, remoteAEs map[string]string, isSync bool) {
+	ss := server{
+		mu:       &sync.Mutex{},
+		datasets: map[string]*godicom.DataSet{},
+	}
+	t.Logf("Listening on %s", port)
+
+	params := netdicom.ServiceProviderParams{
+		AETitle:   aeTitle,
+		RemoteAEs: remoteAEs,
+		CEcho: func(connState netdicom.ConnectionState) dimse.Status {
+			log.Printf("Received C-ECHO")
+			return dimse.Success
+		},
+	}
+	if isSync {
+		params.CStore = func(connState netdicom.ConnectionState, transferSyntaxUID string,
+			sopClassUID string,
+			sopInstanceUID string,
+			data []byte) dimse.Status {
+			return ss.onCStore(transferSyntaxUID, sopClassUID, sopInstanceUID, data)
+		}
+	} else {
+		params.CStoreStream = func(connState netdicom.ConnectionState, transferSyntaxUID string,
+			sopClassUID string,
+			sopInstanceUID string,
+			data chan []byte) dimse.Status {
+			return dimse.Success
+		}
+	}
+	sp, err := netdicom.NewServiceProvider(params, port)
+	require.NoError(t, err)
+	sp.Run()
+}
+
+// newTestClient returns a dicom Client for testing
+func newTestClient(t testing.TB, isSync bool) *netdicom.ServiceUser {
+	var (
+		port = MustAllocateFreePort()
+		host = "localhost"
+	)
+	go func() {
+		runSCPTest(t, net.JoinHostPort("localhost", port), "serverAE", map[string]string{
+			"clientAE": net.JoinHostPort(host, port),
+			"serverAE": net.JoinHostPort(host, port),
+		}, isSync)
+	}()
+	waitForReply(t, port)
+	params := netdicom.ServiceUserParams{SOPClasses: sopclass.VerificationClasses}
+	client, err := netdicom.NewServiceUser(params)
+	require.NoError(t, err)
+	client.Connect(net.JoinHostPort("localhost", port))
+	require.NoError(t, client.CEcho())
+	return client
+}
+
+func newTestDataset(t testing.TB) *godicom.DataSet {
+	pixelData := make([]byte, 10*1000*1000) // 10MB
+	rand.Read(pixelData)
+	var image godicom.PixelDataInfo
+	image.Frames = append(image.Frames, pixelData)
+	var tags = map[dicomtag.Tag]interface{}{
+		dicomtag.MediaStorageSOPClassUID:    "1.2.840.10008.1.1",
+		dicomtag.MediaStorageSOPInstanceUID: "1.2.826.0.1.3680043.2.1143.1590429688519720198888333603882344634",
+		dicomtag.SOPInstanceUID:             "1.2.826.0.1.3680043.2.1143.1590429688519720198888333603882344634",
+		dicomtag.StudyInstanceUID:           "1.2.826.0.1.3680043.2.1143.1590429688519720198888333603882344634",
+		dicomtag.TransferSyntaxUID:          "1.2.840.10008.1.2",
+		dicomtag.PixelData:                  image,
+	}
+	var elements []*godicom.Element
+	for tag, val := range tags {
+		elem, err := godicom.NewElement(tag, val)
+		require.NoError(t, err)
+		elements = append(elements, elem)
+	}
+	ds := godicom.DataSet{Elements: elements}
+	return &ds
+}
+
+func BenchmarkCStoreSync(b *testing.B) {
+	c := newTestClient(b, true)
+	defer c.Release()
+
+	ds := newTestDataset(b)
+	for i := 0; i < b.N; i++ {
+		require.NoError(b, c.CStore(ds))
+	}
+}
+
+func BenchmarkCStoreStream(b *testing.B) {
+	c := newTestClient(b, false)
+	defer c.Release()
+
+	ds := newTestDataset(b)
+	for i := 0; i < b.N; i++ {
+		c.CStore(ds)
+	}
+}

--- a/sampleserver/sampleserver_test.go
+++ b/sampleserver/sampleserver_test.go
@@ -41,7 +41,9 @@ func runSCPTest(t testing.TB, port, aeTitle string, remoteAEs map[string]string,
 		params.CStoreStream = func(connState netdicom.ConnectionState, transferSyntaxUID string,
 			sopClassUID string,
 			sopInstanceUID string,
-			data chan []byte) dimse.Status {
+			dataCh chan []byte) dimse.Status {
+			for range dataCh {
+			}
 			return dimse.Success
 		}
 	}
@@ -72,7 +74,7 @@ func newTestClient(t testing.TB, isSync bool) *netdicom.ServiceUser {
 }
 
 func newTestDataset(t testing.TB) *godicom.DataSet {
-	pixelData := make([]byte, 10*1000*1000) // 10MB
+	pixelData := make([]byte, 100*1000*1000) // 100MB
 	rand.Read(pixelData)
 	var image godicom.PixelDataInfo
 	image.Frames = append(image.Frames, pixelData)

--- a/servicedispatcher.go
+++ b/servicedispatcher.go
@@ -21,10 +21,18 @@ type serviceDispatcher struct {
 	// Set of active DIMSE commands running. Keys are message IDs.
 	activeCommands map[dimse.MessageID]*serviceCommandState // guarded by mu
 
+	// Set of active stream DIMSE commands running. Keys are message IDs.
+	activeStreamCommands map[dimse.MessageID]*serviceCommandState // guarded by mu
+
 	// A callback to be called when a dimse request message arrives. Keys
 	// are DIMSE CommandField. The callback typically creates a new command
 	// by calling findOrCreateCommand.
 	callbacks map[int]serviceCallback // guarded by mu
+
+	// A callback to be called when a dimse request message arrives. Keys
+	// are DIMSE CommandField. The callback typically creates a new command
+	// by calling findOrCreateCommand.
+	streamCallbacks map[int]serviceStreamCallback // guarded by mu
 
 	// The last message ID used in newCommand(). Used to avoid creating duplicate
 	// IDs.
@@ -32,6 +40,8 @@ type serviceDispatcher struct {
 }
 
 type serviceCallback func(msg dimse.Message, data []byte, cs *serviceCommandState)
+
+type serviceStreamCallback func(msg dimse.Message, dataChan chan []byte, cs *serviceCommandState)
 
 // Per-DIMSE-command state.
 type serviceCommandState struct {
@@ -67,10 +77,11 @@ func (cs *serviceCommandState) sendMessage(cmd dimse.Message, data []byte) {
 func (disp *serviceDispatcher) findOrCreateCommand(
 	msgID dimse.MessageID,
 	cm *contextManager,
+	activeCommands map[dimse.MessageID]*serviceCommandState,
 	context contextManagerEntry) (*serviceCommandState, bool) {
 	disp.mu.Lock()
 	defer disp.mu.Unlock()
-	if cs, ok := disp.activeCommands[msgID]; ok {
+	if cs, ok := activeCommands[msgID]; ok {
 		return cs, true
 	}
 	cs := &serviceCommandState{
@@ -80,7 +91,7 @@ func (disp *serviceDispatcher) findOrCreateCommand(
 		context:   context,
 		upcallCh:  make(chan upcallEvent, 128),
 	}
-	disp.activeCommands[msgID] = cs
+	activeCommands[msgID] = cs
 	dicomlog.Vprintf(1, "dicom.serviceDispatcher(%s): Start command %+v", disp.label, cs)
 	return cs, false
 }
@@ -116,9 +127,19 @@ func (disp *serviceDispatcher) deleteCommand(cs *serviceCommandState) {
 	disp.mu.Lock()
 	dicomlog.Vprintf(1, "dicom.serviceDispatcher(%s): Finish provider command %v", disp.label, cs.messageID)
 	if _, ok := disp.activeCommands[cs.messageID]; !ok {
-		panic(fmt.Sprintf("cs %+v", cs))
+		if _, ok = disp.activeStreamCommands[cs.messageID]; !ok {
+			panic(fmt.Sprintf("cs %+v", cs))
+		}
+		delete(disp.activeStreamCommands, cs.messageID)
+	} else {
+		delete(disp.activeCommands, cs.messageID)
 	}
-	delete(disp.activeCommands, cs.messageID)
+	disp.mu.Unlock()
+}
+
+func (disp *serviceDispatcher) registerStreamCallback(commandField int, cb serviceStreamCallback) {
+	disp.mu.Lock()
+	disp.streamCallbacks[commandField] = cb
 	disp.mu.Unlock()
 }
 
@@ -134,7 +155,10 @@ func (disp *serviceDispatcher) unregisterCallback(commandField int) {
 	disp.mu.Unlock()
 }
 
-func (disp *serviceDispatcher) handleEvent(event upcallEvent) {
+func (disp *serviceDispatcher) _handleEvent(
+	event upcallEvent,
+	activeCommands map[dimse.MessageID]*serviceCommandState,
+	cb func(dc *serviceCommandState)) {
 	if event.eventType == upcallEventHandshakeCompleted {
 		return
 	}
@@ -147,20 +171,38 @@ func (disp *serviceDispatcher) handleEvent(event upcallEvent) {
 		return
 	}
 	messageID := event.command.GetMessageID()
-	dc, found := disp.findOrCreateCommand(messageID, event.cm, context)
+	dc, found := disp.findOrCreateCommand(messageID, event.cm, activeCommands, context)
 	if found {
 		dicomlog.Vprintf(1, "dicom.serviceDispatcher(%s): Forwarding command to existing command: %+v %+v", disp.label, event.command, dc)
 		dc.upcallCh <- event
 		dicomlog.Vprintf(1, "dicom.serviceDispatcher(%s): Done forwarding command to existing command: %+v %+v", disp.label, event.command, dc)
 		return
 	}
-	disp.mu.Lock()
-	cb := disp.callbacks[event.command.CommandField()]
-	disp.mu.Unlock()
-	go func() {
-		cb(event.command, event.data, dc)
-		disp.deleteCommand(dc)
-	}()
+	cb(dc)
+}
+
+func (disp *serviceDispatcher) handleEvent(event upcallEvent) {
+	disp._handleEvent(event, disp.activeCommands, func(dc *serviceCommandState) {
+		disp.mu.Lock()
+		cb := disp.callbacks[event.command.CommandField()]
+		disp.mu.Unlock()
+		go func() {
+			cb(event.command, event.data, dc)
+			disp.deleteCommand(dc)
+		}()
+	})
+}
+
+func (disp *serviceDispatcher) handleStreamEvent(event upcallEvent) {
+	disp._handleEvent(event, disp.activeStreamCommands, func(dc *serviceCommandState) {
+		disp.mu.Lock()
+		cb := disp.streamCallbacks[event.command.CommandField()]
+		disp.mu.Unlock()
+		go func() {
+			cb(event.command, event.stream, dc)
+			disp.deleteCommand(dc)
+		}()
+	})
 }
 
 // Must be called exactly once to shut down the dispatcher.
@@ -170,6 +212,9 @@ func (disp *serviceDispatcher) close() {
 		for _, cs := range disp.activeCommands {
 			close(cs.upcallCh)
 		}
+		for _, cs := range disp.activeStreamCommands {
+			close(cs.upcallCh)
+		}
 		disp.mu.Unlock()
 	})
 	// TODO(saito): prevent new command from launching.
@@ -177,10 +222,12 @@ func (disp *serviceDispatcher) close() {
 
 func newServiceDispatcher(label string) *serviceDispatcher {
 	return &serviceDispatcher{
-		label:          label,
-		downcallCh:     make(chan stateEvent, 128),
-		activeCommands: make(map[dimse.MessageID]*serviceCommandState),
-		callbacks:      make(map[int]serviceCallback),
-		lastMessageID:  123,
+		label:                label,
+		downcallCh:           make(chan stateEvent, 128),
+		activeCommands:       make(map[dimse.MessageID]*serviceCommandState),
+		activeStreamCommands: make(map[dimse.MessageID]*serviceCommandState),
+		callbacks:            make(map[int]serviceCallback),
+		streamCallbacks:      make(map[int]serviceStreamCallback),
+		lastMessageID:        123,
 	}
 }

--- a/servicedispatcher.go
+++ b/servicedispatcher.go
@@ -57,9 +57,9 @@ type serviceCommandState struct {
 // Send a command+data combo to the remote peer. data may be nil.
 func (cs *serviceCommandState) sendMessage(cmd dimse.Message, data []byte) {
 	if s := cmd.GetStatus(); s != nil && s.Status != dimse.StatusSuccess && s.Status != dimse.StatusPending {
-		dicomlog.Vprintf(0, "dicom.serviceDispatcher(%s): Sending DIMSE error: %v %v", cs.disp.label, cmd, cs.disp)
+		dicomlog.Vprintf(0, "dicom.serviceDispatcher(%s): Sending DIMSE error: %v", cs.disp.label, cmd)
 	} else {
-		dicomlog.Vprintf(1, "dicom.serviceDispatcher(%s): Sending DIMSE message: %v %v", cs.disp.label, cmd, cs.disp)
+		dicomlog.Vprintf(1, "dicom.serviceDispatcher(%s): Sending DIMSE message: %v", cs.disp.label, cmd)
 	}
 	payload := &stateEventDIMSEPayload{
 		abstractSyntaxName: cs.context.abstractSyntaxUID,

--- a/serviceprovider.go
+++ b/serviceprovider.go
@@ -22,6 +22,31 @@ type CMoveResult struct {
 	DataSet   *dicom.DataSet // Contents of the file.
 }
 
+func handleCStoreStream(
+	cb CStoreStreamCallback,
+	connState ConnectionState,
+	c *dimse.CStoreRq,
+	dataChan chan []byte,
+	cs *serviceCommandState) {
+	status := dimse.Status{Status: dimse.StatusUnrecognizedOperation}
+	if cb != nil {
+		status = cb(
+			connState,
+			cs.context.transferSyntaxUID,
+			c.AffectedSOPClassUID,
+			c.AffectedSOPInstanceUID,
+			dataChan)
+	}
+	resp := &dimse.CStoreRsp{
+		AffectedSOPClassUID:       c.AffectedSOPClassUID,
+		MessageIDBeingRespondedTo: c.MessageID,
+		CommandDataSetType:        dimse.CommandDataSetTypeNull,
+		AffectedSOPInstanceUID:    c.AffectedSOPInstanceUID,
+		Status:                    status,
+	}
+	cs.sendMessage(resp, nil)
+}
+
 func handleCStore(
 	cb CStoreCallback,
 	connState ConnectionState,
@@ -318,6 +343,9 @@ type ServiceProviderParams struct {
 	// If CStoreCallback=nil, a C-STORE call will produce an error response.
 	CStore CStoreCallback
 
+	// If CStoreCallback=nil, a C-STORE call will produce an error response.
+	CStoreStream CStoreStreamCallback
+
 	// TLSConfig, if non-nil, enables TLS on the connection. See
 	// https://gist.github.com/michaljemala/d6f4e01c4834bf47a9c4 for an
 	// example for creating a TLS config from x509 cert files.
@@ -348,6 +376,14 @@ type CStoreCallback func(
 	sopClassUID string,
 	sopInstanceUID string,
 	data []byte) dimse.Status
+
+// CStoreStreamCallback is called C-STORE request with a channel to receive the payload
+type CStoreStreamCallback func(
+	conn ConnectionState,
+	transferSyntaxUID string,
+	sopClassUID string,
+	sopInstanceUID string,
+	dataChan chan []byte) dimse.Status
 
 // CFindCallback implements a C-FIND handler.  sopClassUID is the data type
 // requested (e.g.,"1.2.840.10008.5.1.4.1.1.1.2"), and transferSyntaxUID is the
@@ -493,8 +529,13 @@ func getConnState(conn net.Conn) (cs ConnectionState) {
 // function returns immediately; "conn" will be cleaned up in the background.
 func RunProviderForConn(conn net.Conn, params ServiceProviderParams) {
 	upcallCh := make(chan upcallEvent, 128)
+	upcallStreamCh := make(chan upcallEvent, 128)
 	label := newUID("sc")
 	disp := newServiceDispatcher(label)
+	disp.registerStreamCallback(dimse.CommandFieldCStoreRq,
+		func(msg dimse.Message, data chan []byte, cs *serviceCommandState) {
+			handleCStoreStream(params.CStoreStream, getConnState(conn), msg.(*dimse.CStoreRq), data, cs)
+		})
 	disp.registerCallback(dimse.CommandFieldCStoreRq,
 		func(msg dimse.Message, data []byte, cs *serviceCommandState) {
 			handleCStore(params.CStore, getConnState(conn), msg.(*dimse.CStoreRq), data, cs)
@@ -515,7 +556,12 @@ func RunProviderForConn(conn net.Conn, params ServiceProviderParams) {
 		func(msg dimse.Message, data []byte, cs *serviceCommandState) {
 			handleCEcho(params, getConnState(conn), msg.(*dimse.CEchoRq), data, cs)
 		})
-	go runStateMachineForServiceProvider(conn, upcallCh, disp.downcallCh, label)
+	go func() {
+		runStateMachineForServiceProvider(conn, upcallCh, upcallStreamCh, disp.downcallCh, label)
+		for event := range upcallStreamCh {
+			disp.handleStreamEvent(event)
+		}
+	}()
 	for event := range upcallCh {
 		disp.handleEvent(event)
 	}

--- a/serviceprovider.go
+++ b/serviceprovider.go
@@ -563,7 +563,7 @@ func RunProviderForConn(conn net.Conn, params ServiceProviderParams) {
 		runStateMachineForServiceProvider(conn, upcallStreamCh, disp.downcallCh, label)
 	}()
 	for event := range upcallStreamCh {
-		disp.handleStreamEvent(event)
+		disp.handleEvent(event)
 	}
 	dicomlog.Vprintf(0, "dicom.serviceProvider(%s): Finished connection %p (remote: %+v)", label, conn, conn.RemoteAddr())
 	disp.close()

--- a/serviceuser.go
+++ b/serviceuser.go
@@ -134,7 +134,7 @@ func NewServiceUser(params ServiceUserParams) (*ServiceUser, error) {
 				continue
 			}
 			doassert(event.eventType == upcallEventData)
-			su.disp.handleStreamEvent(event)
+			su.disp.handleEvent(event)
 		}
 		dicomlog.Vprintf(1, "dicom.serviceUser: dispatcher finished")
 		su.disp.close()

--- a/statemachine.go
+++ b/statemachine.go
@@ -344,16 +344,25 @@ var actionDt1 = &stateAction{"DT-1", "Send P-DATA-TF PDU",
 
 var actionDt2 = &stateAction{"DT-2", "Send P-DATA indication primitive",
 	func(sm *stateMachine, event stateEvent) stateType {
-		contextID, command, data, err := sm.commandAssembler.AddDataPDU(event.pdu.(*pdu.PDataTf))
+		result, err := sm.commandAssembler.AddDataPDU(event.pdu.(*pdu.PDataTf))
 		if err == nil {
-			if command != nil { // All fragments received
-				dicomlog.Vprintf(1, "dicom.stateMachine(%s): DIMSE request: %v", sm.label, command)
+			if result.First {
+				sm.upcallStreamCh <- upcallEvent{
+					eventType: upcallEventData,
+					cm:        sm.contextManager,
+					contextID: result.ContextID,
+					command:   result.Command,
+					stream:    result.Stream,
+					data:      result.DataBytes}
+			}
+			if result.Last && result.Command != nil { // All fragments received
+				dicomlog.Vprintf(1, "dicom.stateMachine(%s): DIMSE request: %v", sm.label, result.Command)
 				sm.upcallCh <- upcallEvent{
 					eventType: upcallEventData,
 					cm:        sm.contextManager,
-					contextID: contextID,
-					command:   command,
-					data:      data}
+					contextID: result.ContextID,
+					command:   result.Command,
+					data:      result.DataBytes}
 			}
 			return sta06
 		}
@@ -539,6 +548,7 @@ type upcallEvent struct {
 
 	command dimse.Message
 	data    []byte
+	stream  chan []byte
 }
 
 type stateEventDIMSEPayload struct {
@@ -745,6 +755,10 @@ type stateMachine struct {
 	// For sending indications to the the upper layer. Owned by the
 	// statemachine.
 	upcallCh chan upcallEvent
+
+	// For sending indications to the the upper layer. Owned by the
+	// statemachine.
+	upcallStreamCh chan upcallEvent
 
 	// For Timer expiration event
 	timerCh chan stateEvent
@@ -964,18 +978,21 @@ func runStateMachineForServiceUser(
 func runStateMachineForServiceProvider(
 	conn net.Conn,
 	upcallCh chan upcallEvent,
+	upcallStreamCh chan upcallEvent,
 	downcallCh chan stateEvent,
 	label string) {
 	sm := &stateMachine{
-		label:          label,
-		isUser:         false,
-		contextManager: newContextManager(label),
-		conn:           conn,
-		netCh:          make(chan stateEvent, 128),
-		errorCh:        make(chan stateEvent, 128),
-		downcallCh:     downcallCh,
-		upcallCh:       upcallCh,
-		faults:         getProviderFaultInjector(),
+		label:            label,
+		isUser:           false,
+		contextManager:   newContextManager(label),
+		conn:             conn,
+		netCh:            make(chan stateEvent, 128),
+		errorCh:          make(chan stateEvent, 128),
+		downcallCh:       downcallCh,
+		upcallCh:         upcallCh,
+		upcallStreamCh:   upcallStreamCh,
+		faults:           getProviderFaultInjector(),
+		commandAssembler: dimse.NewCommandAssembler(),
 	}
 	event := stateEvent{event: evt05, conn: conn}
 	action := findAction(sta01, &event, sm.label)

--- a/statemachine.go
+++ b/statemachine.go
@@ -956,15 +956,16 @@ func runStateMachineForServiceUser(
 	doassert(len(params.SOPClasses) > 0)
 	doassert(len(params.TransferSyntaxes) > 0)
 	sm := &stateMachine{
-		label:          label,
-		isUser:         true,
-		contextManager: newContextManager(label),
-		userParams:     params,
-		netCh:          make(chan stateEvent, 128),
-		errorCh:        make(chan stateEvent, 128),
-		downcallCh:     downcallCh,
-		upcallCh:       upcallCh,
-		faults:         getUserFaultInjector(),
+		label:            label,
+		isUser:           true,
+		contextManager:   newContextManager(label),
+		userParams:       params,
+		netCh:            make(chan stateEvent, 128),
+		errorCh:          make(chan stateEvent, 128),
+		downcallCh:       downcallCh,
+		upcallCh:         upcallCh,
+		faults:           getUserFaultInjector(),
+		commandAssembler: dimse.NewCommandAssembler(),
 	}
 	event := stateEvent{event: evt01}
 	action := findAction(sta01, &event, sm.label)


### PR DESCRIPTION
When receive a large image (more than 1 GB), there's a OOM error from dmesg
```
[7318449.362363] oom-kill:constraint=CONSTRAINT_NONE,nodemask=(null),cpuset=/,mems_allowed=0,global_oom,task_memcg=/user.slice/user-1000.slice/session-259129.scope,task=segpiper_dcmd,pid=534707,uid=996
[7318449.362379] Out of memory: Killed process 534707 (segpiper_dcmd) total-vm:17421456kB, anon-rss:15436588kB, file-rss:0kB, shmem-rss:0kB, UID:996 pgtables:32832kB oom_score_adj:0
[7318449.700102] oom_reaper: reaped process 534707 (segpiper_dcmd), now anon-rss:0kB, file-rss:0kB, shmem-rss:0kB
```
During a C_STORE request, if this metadata could be retrieved in a stream of images consistently, it would enable us to ignore those images that we don't want and avoid OOM error.
