### PR TITLE
Add missing ImplementationClassUIDSubItem and ImplementationVersionNameSubItem in A-ASSOCIATE-AC message

### DIFF
--- a/contextmanager.go
+++ b/contextmanager.go
@@ -179,7 +179,11 @@ func (m *contextManager) onAssociateRequest(requestItems []pdu.SubItem) ([]pdu.S
 	}
 	responses = append(responses,
 		&pdu.UserInformationItem{
-			Items: []pdu.SubItem{&pdu.UserInformationMaximumLengthItem{MaximumLengthReceived: uint32(DefaultMaxPDUSize)}}})
+			Items: []pdu.SubItem{
+				&pdu.UserInformationMaximumLengthItem{MaximumLengthReceived: uint32(DefaultMaxPDUSize)},
+				&pdu.ImplementationClassUIDSubItem{dicom.GoDICOMImplementationClassUID},
+				&pdu.ImplementationVersionNameSubItem{dicom.GoDICOMImplementationVersionName},
+			}})
 	dicomlog.Vprintf(1, "dicom.onAssociateRequest(%s): Received associate request, #contexts:%v, maxPDU:%v, implclass:%v, version:%v",
 		m.label, len(m.contextIDToAbstractSyntaxNameMap),
 		m.peerMaxPDUSize, m.peerImplementationClassUID, m.peerImplementationVersionName)


### PR DESCRIPTION
According to DICOM Standard https://dicom.nema.org/medical/dicom/current/output/chtml/part07/sect_d.3.3.2.html, Implementation identification is required to implement of communicating AEs to identify each other at Association establishment time. 