### PR TITLE
return the NumberOfStudyRelatedInstances after calling the C-MOVE com…

### DIFF
--- a/sampleclient/sampleclient.go
+++ b/sampleclient/sampleclient.go
@@ -91,10 +91,13 @@ func cMove() {
 	su := newServiceUser(sopclass.QRMoveClasses)
 	defer su.Release()
 	qrLevel, args := generateCFindElements()
-	if err := su.CMove(*moveAETitleFlag, qrLevel, args); err != nil {
+	resp, err := su.CMove(*moveAETitleFlag, qrLevel, args)
+	if err != nil {
 		log.Printf("C-MOVE error: %v", err)
 	} else {
-		log.Print("C-MOVE finished")
+		log.Print("C-MOVE finished\n")
+		log.Printf("NumberOfCompletedSuboperations: %d\n", resp.NumberOfCompletedSuboperations)
+		log.Printf("NumberOfFailedSuboperations: %d\n", resp.NumberOfFailedSuboperations)
 	}
 }
 


### PR DESCRIPTION
Modify the go-netdicom library to return the NumberOfStudyRelatedInstances after calling the C-MOVE command.

## How to test
```
git checkout DPI2-783/revamp-c-move
cd sampleserver
go run .
```
Open a new terminal window and run
```
go run . -move -study=1.2.826.0.1.3680043.2.1143.2592092611698916978113112155415165916 -server=localhost:10000 -remote-ae-title=bogusae -ae-title=GBMAC0261 -move-ae-title=GBMAC0261
# expect
2024/06/25 21:36:35 Connecting to localhost:10000
2024/06/25 21:36:35 C-MOVE finished
2024/06/25 21:36:35 NumberOfCompletedSuboperations: 0
2024/06/25 21:36:35 NumberOfFailedSuboperations: 1
```
Open a new terminal window and run
```
storescp 11112 &
go run . -move -study=1.2.826.0.1.3680043.2.1143.2592092611698916978113112155415165916 -server=localhost:10000 -remote-ae-title=bogusae -ae-title=GBMAC0261 -move-ae-title=GBMAC0261
# expect 
2024/06/25 21:37:55 Connecting to localhost:10000
2024/06/25 21:37:55 C-MOVE finished
2024/06/25 21:37:55 NumberOfCompletedSuboperations: 1
2024/06/25 21:37:55 NumberOfFailedSuboperations: 0
```